### PR TITLE
Fix nested template literal in worker HTML script

### DIFF
--- a/Jack Script
+++ b/Jack Script
@@ -1113,7 +1113,7 @@ goBtn.addEventListener("click", async ()=>{
     const r = await fetch(u, { cache: "no-store" });
     const data = await r.json();
     render(data.results||[]); debugEl.textContent = JSON.stringify(data.diag||data,null,2);
-    setStatus(\`done (\${(data.results||[]).length})\`);
+    setStatus('done (' + ((data.results || []).length) + ')');
   }catch(e){ setStatus("error"); debugEl.textContent=String(e); }
 });
 loadDefaults();


### PR DESCRIPTION
## Summary
- Replace broken inline template literal in HTML UI with safe string concatenation to restore `setStatus` call

## Testing
- `node --check 'Jack Script'`


------
https://chatgpt.com/codex/tasks/task_e_68b08454631c832bb2df3a3e29d76cf2